### PR TITLE
feat: add health check endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/ping")
+def ping():
+    """Health check endpoint for service verification"""
+    return "pong"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.104.1
+uvicorn==0.24.0


### PR DESCRIPTION
## Overview
Create a simple health check endpoint to verify the FastAPI service is running properly.

## Changes
- Add GET /ping endpoint that returns 'pong' string
- Implement using FastAPI framework  
- Add requirements.txt with FastAPI and Uvicorn dependencies
- Endpoint returns 200 status code as expected

## Testing
- ✅ Built and tested with Docker container
- ✅ Verified GET /ping returns 'pong' with 200 status
- ✅ FastAPI server starts correctly
- ✅ Endpoint responds to HTTP requests

## Acceptance Criteria Met
- ✅ GET request to /ping returns 'pong'
- ✅ Response has 200 status code  
- ✅ Only one endpoint implemented (minimal implementation)
- ✅ Uses FastAPI framework

This endpoint will be used by monitoring systems to check if the API is responsive.